### PR TITLE
Use bigtruedata/sbt for packaging

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,8 +1,7 @@
 steps:
-  - command: |
-      jdk_switcher use oraclejdk8 && \
-      sbt package
+  - command: sbt package
     plugins:
       docker#v1.1.1:
-        image: "quay.io/travisci/travis-jvm:latest"
-        workdir: /home/travis
+        image: bigtruedata/sbt
+        workdir: /app
+    artifact_paths: "target/**/*.jar"


### PR DESCRIPTION
Switches to [bigtrudata/sbt](https://hub.docker.com/r/bigtruedata/sbt/) which is a little more light-weight than the travis-jvm image, and uploads the resulting jar as an artifact.

<img width="743" alt="bigtruedata-sbt" src="https://user-images.githubusercontent.com/153/38346390-213c9d14-38d8-11e8-80f7-bffca7c77271.png">

Most of the build time is downloading sbt 0.13.16 (which the image doesn't include for some reason) 😐

The `hseeberger/scala-sbt` image is much the same: https://github.com/toolmantim/enigma/blob/use-hseeberger-scala-sbt/.buildkite/pipeline.yml